### PR TITLE
Update project version and enhance return type handling

### DIFF
--- a/BlazorExpress.Bulma.Docx/BlazorExpress.Bulma.Docx.csproj
+++ b/BlazorExpress.Bulma.Docx/BlazorExpress.Bulma.Docx.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <PackageId>BlazorExpress.Bulma.Docx</PackageId>
-    <Version>0.2.0</Version>
-    <PackageVersion>0.2.0</PackageVersion>
+    <Version>0.2.1</Version>
+    <PackageVersion>0.2.1</PackageVersion>
     <PackageIconUrl>logo.png</PackageIconUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/BlazorExpress/BlazorExpress.Bulma.Docx</PackageProjectUrl>
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BlazorExpress.Bulma" Version="0.1.0" />
+    <PackageReference Include="BlazorExpress.Bulma" Version="0.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BlazorExpress.Bulma.Docx/Components/DocxTable/DocxMethodRow.razor.cs
+++ b/BlazorExpress.Bulma.Docx/Components/DocxTable/DocxMethodRow.razor.cs
@@ -6,7 +6,7 @@ public partial class DocxMethodRow<TItem> : ComponentBase
 
     private string Description => MethodInfo.GetMethodDescription();
 
-    public string ReturnType => MethodInfo.GetMethodReturnType();
+    public string ReturnType => MethodInfo.GetMethodReturnTypeName() ?? MethodInfo.GetMethodReturnType();
 
     public string MethodNameWithParameters => $"{MethodInfo.Name}({MethodParameters})";
 

--- a/BlazorExpress.Bulma.Docx/Extensions/MethodInfoExtensions.cs
+++ b/BlazorExpress.Bulma.Docx/Extensions/MethodInfoExtensions.cs
@@ -50,4 +50,15 @@ public static class MethodInfoExtensions
     /// <returns>string</returns>
     public static string GetMethodReturnType(this MethodInfo methodInfo) 
         => methodInfo.ReturnType.GetCSharpTypeName();
+
+    /// <summary>
+    /// Get method return type name.
+    /// </summary>
+    /// <param name="methodInfo"></param>
+    /// <returns>string</returns>
+    public static string GetMethodReturnTypeName(this MethodInfo methodInfo)
+    {
+        var parameterTypeNameAttribute = methodInfo.GetCustomAttributes(typeof(MethodReturnTypeNameAttribute), false).FirstOrDefault() as MethodReturnTypeNameAttribute;
+        return parameterTypeNameAttribute?.TypeName ?? null!;
+    }
 }


### PR DESCRIPTION
Updated the project version to `0.2.1` and the `PackageReference` for `BlazorExpress.Bulma` to version `0.1.1`. Modified the `ReturnType` property in `DocxMethodRow.razor.cs` to use a new method `GetMethodReturnTypeName()`, providing a more descriptive return type. Added the `GetMethodReturnTypeName` method in `MethodInfoExtensions.cs` to retrieve the return type name based on a custom attribute.

NOTE: This commit message is auto-generated using GitHub Copilot.